### PR TITLE
Fix elpy on macos

### DIFF
--- a/emacs.d/packages.d/elpy.el
+++ b/emacs.d/packages.d/elpy.el
@@ -1,8 +1,10 @@
 ;;; elpy
 
 ;; Provides a python programming toolset.
-(when (executable-find "python")
+(when (executable-find "python3")
   (use-package elpy
     :ensure
     :config
-    (elpy-enable)))
+    (setq elpy-rpc-python-command "python3")
+    (elpy-enable))
+)


### PR DESCRIPTION
Elpy was trying to use the system python 2 and it failed to create the ~/.emacs.d/elpy/rpc-env since it does not have virtualenv installed.
My solution was to force it to use python3.
I also only load elpy if there is a python3 installed.